### PR TITLE
Add default path for incorrect urls

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,8 +18,9 @@ class UsersController < ApplicationController
     @user = current_user
     if current_admin?
         redirect_to admin_dashboard_path
+    elsif current_user
     else
-      current_user
+      render file: "/public/404"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,5 @@ Rails.application.routes.draw do
 
   get "/:slug", to: "categories#show", as: 'category'
 
+  get '*path' => redirect('/')
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-ActiveRecord::Schema.define(version: 20160610204714) do
-=======
 ActiveRecord::Schema.define(version: 20160610211756) do
->>>>>>> dev
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/features/unauthenticated_user_security_spec.rb
+++ b/spec/features/unauthenticated_user_security_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.feature "Unauthorized user doesn't have acess to other's data" do
+  scenario "visitor cannot view user dashboard page" do
+    visit root_path
+
+    visit ("/dashboard")
+
+
+    expect(page).to have_content("The page you were looking for doesn't exist")
+  end
+
+  
+end


### PR DESCRIPTION
Add 404 page for users when they try to access dashboard.  Catch all reroute for incorrect url paths. 
